### PR TITLE
Updating svg version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^0.1.3
-  flutter_svg: ^0.17.4 # it help us to use SVG in our app
+  flutter_svg: ^0.18.0 # it help us to use SVG in our app
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
It was unable to run in ios simulator because of svg package issue. Updating the version resolved it and was able to run in ios simulator.